### PR TITLE
Add managed process launcher and integration test

### DIFF
--- a/Autoball.py
+++ b/Autoball.py
@@ -3,7 +3,9 @@ import subprocess
 import signal
 import sys
 import os
-from auto_utils.logger import get_logger
+from typing import List
+
+from auto_utils import ManagedProcess, get_logger, launch_process
 
 # Rutas absolutas de los ejecutables
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -11,20 +13,20 @@ CONTROLMPP_BIN = os.path.join(PROJECT_DIR, "ControlMPP/bin/ControlMPP")
 VIDEOCAPTURE_SCRIPT = os.path.join(PROJECT_DIR, "VideoCapture/VideoCapture.py")
 
 # Lista para guardar procesos lanzados
-processes = []
+processes: List[ManagedProcess] = []
 
-log= get_logger("MAIN")
+log = get_logger("MAIN")
 
 def start():
     log.info("Starting ControlMPP...")
-    control_proc = subprocess.Popen([CONTROLMPP_BIN], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    control_proc = launch_process([CONTROLMPP_BIN], logger=log, name="ControlMPP")
     processes.append(control_proc)
 
     log.info("Starting VideoCapture...")
-    video_proc = subprocess.Popen(
-        ["python3", VIDEOCAPTURE_SCRIPT, "--source", "camera"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+    video_proc = launch_process(
+        [sys.executable, VIDEOCAPTURE_SCRIPT, "--source", "camera"],
+        logger=log,
+        name="VideoCapture",
     )
     processes.append(video_proc)
 
@@ -38,6 +40,10 @@ def stop(signum=None, frame=None):
             except subprocess.TimeoutExpired:
                 log.info(f"Forzando kill a PID {proc.pid}")
                 proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            log.warning(f"Timeout esperando la terminación del proceso {proc.pid}")
     sys.exit(0)
 
 if __name__ == "__main__":

--- a/auto_utils/__init__.py
+++ b/auto_utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers for the Autoball project."""
+
+from .logger import get_logger
+from .process import ManagedProcess, launch_process
+
+__all__ = ["get_logger", "ManagedProcess", "launch_process"]

--- a/auto_utils/process.py
+++ b/auto_utils/process.py
@@ -1,0 +1,162 @@
+"""Utilities for launching subprocesses with robust logging."""
+
+from __future__ import annotations
+
+import logging
+import signal
+import subprocess
+import threading
+from typing import Iterable, List, Optional, Sequence, Union
+
+_STREAM_CHUNK_SIZE = 4096
+
+
+def _log_line(logger: Optional[logging.Logger], level: int, prefix: str, text: str) -> None:
+    """Send a single line to the provided logger, if any."""
+    if logger is None:
+        return
+    message = text.rstrip("\r")
+    if prefix:
+        logger.log(level, f"[{prefix}] {message}")
+    else:
+        logger.log(level, message)
+
+
+def _drain_stream(
+    stream,
+    logger: Optional[logging.Logger],
+    level: int,
+    prefix: str,
+) -> None:
+    """Continuously read from *stream* and forward its content to *logger*.
+
+    The function reads the stream in chunks to avoid blocking when the child
+    process writes large amounts of data without flushing newlines.
+    """
+    buffer = ""
+    try:
+        while True:
+            chunk = stream.read(_STREAM_CHUNK_SIZE)
+            if not chunk:
+                break
+            if isinstance(chunk, bytes):
+                chunk = chunk.decode("utf-8", errors="replace")
+            buffer += chunk
+            while True:
+                newline_index = buffer.find("\n")
+                if newline_index == -1:
+                    break
+                line, buffer = buffer[:newline_index], buffer[newline_index + 1 :]
+                _log_line(logger, level, prefix, line)
+            if len(buffer) > _STREAM_CHUNK_SIZE:
+                _log_line(logger, level, prefix, buffer)
+                buffer = ""
+        if buffer:
+            _log_line(logger, level, prefix, buffer)
+    finally:
+        try:
+            stream.close()
+        except Exception:
+            pass
+
+
+def _start_stream_thread(
+    stream,
+    logger: Optional[logging.Logger],
+    level: int,
+    prefix: str,
+) -> Optional[threading.Thread]:
+    if stream is None:
+        return None
+    thread = threading.Thread(
+        target=_drain_stream,
+        args=(stream, logger, level, prefix),
+        name=f"{prefix}-logger",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+class ManagedProcess:
+    """Wraps :class:`subprocess.Popen` ensuring stdout/stderr pipes are drained."""
+
+    def __init__(self, popen: subprocess.Popen, drain_threads: Iterable[Optional[threading.Thread]]):
+        self._popen = popen
+        self._drain_threads: List[threading.Thread] = [t for t in drain_threads if t is not None]
+        self._joined = False
+
+    def __getattr__(self, item):
+        return getattr(self._popen, item)
+
+    def poll(self) -> Optional[int]:
+        return self._popen.poll()
+
+    def wait(self, timeout: Optional[float] = None) -> int:
+        try:
+            return self._popen.wait(timeout=timeout)
+        finally:
+            if self._popen.poll() is not None:
+                self._join_threads()
+
+    def _join_threads(self) -> None:
+        if self._joined:
+            return
+        for thread in self._drain_threads:
+            thread.join()
+        self._joined = True
+
+    def terminate(self) -> None:
+        self._popen.terminate()
+
+    def kill(self) -> None:
+        self._popen.kill()
+
+    def send_signal(self, sig: Union[int, signal.Signals]) -> None:
+        self._popen.send_signal(sig)
+
+    @property
+    def pid(self) -> int:
+        return self._popen.pid
+
+    @property
+    def returncode(self) -> Optional[int]:
+        return self._popen.returncode
+
+
+def launch_process(
+    command: Union[Sequence[str], str],
+    *,
+    logger: Optional[logging.Logger] = None,
+    name: Optional[str] = None,
+    inherit_streams: bool = False,
+    stdout_level: int = logging.INFO,
+    stderr_level: int = logging.ERROR,
+    **popen_kwargs,
+) -> ManagedProcess:
+    """Launch *command* and ensure stdout/stderr pipes never block the child.
+
+    When *inherit_streams* is ``False`` (default), stdout and stderr are piped
+    and drained using background threads. Each captured line is logged using the
+    provided *logger*. If *inherit_streams* is ``True`` the child inherits the
+    parent's file descriptors.
+    """
+    if "stdout" in popen_kwargs or "stderr" in popen_kwargs:
+        raise ValueError("launch_process controls stdout/stderr; do not override them")
+
+    if inherit_streams:
+        popen = subprocess.Popen(command, **popen_kwargs)
+        return ManagedProcess(popen, [])
+
+    popen = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **popen_kwargs,
+    )
+
+    process_name = name or (command if isinstance(command, str) else " ".join(map(str, command)))
+    stdout_thread = _start_stream_thread(popen.stdout, logger, stdout_level, f"{process_name} stdout")
+    stderr_thread = _start_stream_thread(popen.stderr, logger, stderr_level, f"{process_name} stderr")
+
+    return ManagedProcess(popen, [stdout_thread, stderr_thread])

--- a/test/test_process_launcher.py
+++ b/test/test_process_launcher.py
@@ -1,0 +1,59 @@
+"""Integration tests for the process launching utilities."""
+import io
+import logging
+import subprocess
+import sys
+import unittest
+
+from auto_utils import launch_process
+
+
+class LaunchProcessIntegrationTests(unittest.TestCase):
+    """Verify that processes with large stdout/stderr output do not block."""
+
+    def setUp(self) -> None:
+        logger_name = f"{self.__class__.__name__}.{self._testMethodName}"
+        self.logger = logging.getLogger(logger_name)
+        self.logger.setLevel(logging.DEBUG)
+        self.logger.propagate = False
+        self.stream = io.StringIO()
+        handler = logging.StreamHandler(self.stream)
+        handler.setLevel(logging.DEBUG)
+        for existing in list(self.logger.handlers):
+            self.logger.removeHandler(existing)
+        self.logger.addHandler(handler)
+        self._handler = handler
+
+    def tearDown(self) -> None:
+        self.logger.removeHandler(self._handler)
+        self._handler.close()
+
+    def test_large_output_process_completes(self) -> None:
+        chunk_size = 70_000  # >64 KB ensures the pipe buffers would fill without draining
+        script = (
+            "import sys\n"
+            f"sys.stdout.write('A' * {chunk_size})\n"
+            "sys.stdout.flush()\n"
+            f"sys.stderr.write('B' * {chunk_size})\n"
+            "sys.stderr.flush()\n"
+        )
+
+        process = launch_process(
+            [sys.executable, "-c", script],
+            logger=self.logger,
+            name="dummy-large-output",
+        )
+
+        try:
+            exit_code = process.wait(timeout=5)
+        except subprocess.TimeoutExpired as exc:
+            self.fail(f"Process blocked due to undrained pipes: {exc}")
+
+        self.assertEqual(exit_code, 0)
+        logged_output = self.stream.getvalue()
+        self.assertIn("dummy-large-output stdout", logged_output)
+        self.assertIn("dummy-large-output stderr", logged_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable helper for spawning subprocesses that drains stdout/stderr using background threads
- update Autoball.start to launch ControlMPP and VideoCapture with the managed helper to avoid pipe back pressure
- introduce an integration test that spawns a noisy dummy process to ensure the helper handles >64 KiB of output

## Testing
- python -m unittest discover -s test

------
https://chatgpt.com/codex/tasks/task_e_68d1388fb47083318636870ed1e17f06